### PR TITLE
set up local storage to hold previouse searches

### DIFF
--- a/src/components/Demo.jsx
+++ b/src/components/Demo.jsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react'
 import {FiLink2} from 'react-icons/fi'
 import {BiSearchAlt} from 'react-icons/bi'
+import { useLazyGetSummaryQuery } from '../services/article'
 
 
 function Demo() {
@@ -8,10 +9,38 @@ function Demo() {
   const [article, setArticle] = useState({
     url: '',
     summary: '',
-  })
+  });
+
+  const [allArticles, setAllArticles] = useState([])
+
+  const [getSummary, {error, isFetching}] = useLazyGetSummaryQuery();
+
+
+  useEffect(() => {
+    const articlesFromLocalStorage = JSON.parse(
+      localStorage.getItem('articles')
+    )
+    if(articlesFromLocalStorage){
+      setAllArticles(articlesFromLocalStorage)
+    }
+  }, []);
+
 
   const submit = async (e) => {
-    alert('OHHHHH')
+    e.preventDefault();
+    const {data} = await getSummary({ articleUrl: article.url})
+
+    if(data?.summary){
+      const newArticle = {...article, summary: data.summary};
+
+      const updatedArticalArr =[newArticle, ...allArticles];
+
+      setArticle(newArticle);
+
+      setAllArticles(updatedArticalArr)
+
+      localStorage.setItem('articles', JSON.stringify(updatedArticalArr))
+    }
   }
 
 

--- a/src/services/article.js
+++ b/src/services/article.js
@@ -1,6 +1,7 @@
 import {createApi, fetchBaseQuery} from '@reduxjs/toolkit/query/react'
 
 const apiKey = import.meta.env.VITE_API_KEY
+//TODO: Add a function to adjust paragraph length
 
 export const articleApi = createApi({
   reducerPath: 'articleApi',
@@ -15,7 +16,9 @@ export const articleApi = createApi({
   }),
   endpoints: (builder) => ({
     getSummary: builder.query({
-      query: (params) => 'test'
+      query: (params) => `/summarize?url=${encodeURIComponent(params.articleUrl)}&length=3`
     })
   })
-})
+});
+
+export const {useLazyGetSummaryQuery} = articleApi;


### PR DESCRIPTION
In this commit, I:
- Expanded on the submit function in the Demo.jsx component by: 
1. Fetching the summary data and setting it to _articleURL_
2. Create a new article object with the summary
3. Update the state with the new article
4. Update the state with the new article added to the list of all articles
5. Update the _localStorage_ with the updated list of articles
- Used the ```useState``` hook to create an array that holds previously searched articles.
- Used the ```useEffect``` hook to retrieve articles that are set into local storage.